### PR TITLE
Put metadata into a separate container

### DIFF
--- a/build.py
+++ b/build.py
@@ -59,9 +59,14 @@ def printBreadcrumbs(*items):
     return output
 
 def printLyrics(text):
-    paragraphed = re.sub('\n\n+', '</p><p>', text)
-    linebroken = re.sub('\n', '<br/>', paragraphed)
-    return '<p>' + linebroken + '</p>'
+    # Wrap metadata into a container
+    regex = re.compile(r'_+\n(.*)$', re.DOTALL)
+    text = regex.sub(r'<div class="metadata">\1</div>', text)
+    # Separate text into paragraphs
+    text = re.sub('\n\n+', '</p><p>', text)
+    # Convert newline characters into linebreaks
+    text = re.sub('\n', '<br/>', text)
+    return '<p>' + text + '</p>'
 
 def printDescriptionList(items):
     return ', '.join(items[:24])

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -143,6 +143,15 @@ nav,
     }
 
 
+/*
+ * Purpose: make metadata look different from the song text
+ *
+ */
+.metadata {
+    opacity: 0.4;
+}
+
+
 .error {
     color: #c00;
 }


### PR DESCRIPTION
This wraps everything below a separating line into a DIV to make it easier to visually separate song text from metadata